### PR TITLE
Allow server side rendering. 

### DIFF
--- a/src/DiscussionEmbed.jsx
+++ b/src/DiscussionEmbed.jsx
@@ -3,7 +3,7 @@ import { insertScript, removeScript } from './utils';
 
 export class DiscussionEmbed extends React.Component {
     componentWillMount() {
-        if (window && window.disqus_shortname && window.disqus_shortname !== this.props.shortname)
+        if (typeof window !== 'undefined' && window.disqus_shortname && window.disqus_shortname !== this.props.shortname)
             this.cleanInstance();
     }
 


### PR DESCRIPTION
`componentWillMount` may be called on the server side.

But this line:
```js
if (window && window.disqus_shortname && window.disqus_shortname !== this.props.shortname) {
```

WIll throw:

`ReferenceError: window is not defined`